### PR TITLE
Add 13F Insight to Portfolio Tracker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The curated list of resources for research and learning about stock trading and 
 - [MSCI - Market Insights](https://www.msci.com/research-and-insights/market-insights) - Market commentaries and research reports with a focus on macroeconomic topics.
 
 ## Portfolio Tracker
+- [13F Insight](https://13finsight.com) - Tracks institutional investor 13F filings and hedge fund portfolio movements, allowing users to follow what top investors like Buffett, Ackman, and Soros are buying and selling.
 - [Portfolio Visualizer](https://portfoliovisualizer.com) - Portfolio management and analysis tool that provides portfolio optimization, backtesting, and risk analysis.
 - [Wealthica](https://www.wealthica.com) - Wealth management platform that provides portfolio management, financial planning, and investment research.
 


### PR DESCRIPTION
## What does this PR add?

Adds [13F Insight](https://13finsight.com) to the **Portfolio Tracker** section.

## About 13F Insight

13F Insight is a tool that tracks institutional investor 13F SEC filings and hedge fund portfolio movements, allowing traders and investors to:

- Follow what top investors (Buffett, Ackman, Soros, etc.) are buying and selling
- Track portfolio changes quarter-by-quarter
- Analyze sector and stock trends across hundreds of hedge funds

It's a free tool focused on 13F filings data — commonly used by active investors to track smart money flows.

## Why it fits here

The Portfolio Tracker section lists tools for tracking investments. 13F Insight is directly relevant for stock traders who want to analyze institutional investor strategies.