### PR TITLE
Add Adanos Sentiment API to Stock APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The curated list of resources for research and learning about stock trading and 
 - [StockTwits Top 10](https://stocktwits.com/rankings/trending) - StockTwits' list of the top 10 trending stocks.
 
 ## Stock APIs
+- [Adanos Sentiment API](https://api.adanos.org/docs/) - Finance Sentiment API unifies Reddit, X, financial news, Polymarket, and crypto community data in one API for sentiment analysis and market research.
 - [Alpha Vantage](https://www.alphavantage.co/) - Alpha Vantage offers free APIs for realtime and historical stock data, forex, and cryptocurrency data.
 - [Eodhistoricaldata](https://eodhistoricaldata.com) - Eodhistoricaldata offers APIs for realtime and historical stock data, forex, and cryptocurrency data.
 - [Financial Modeling Prep](https://site.financialmodelingprep.com/) - Financial Modeling Prep API provides real time stock price, company financial statements, major index prices, stock historical data, forex real time rate and cryptocurrencies.


### PR DESCRIPTION
## Summary
- Adds [Adanos Sentiment API](https://api.adanos.org/docs/) to the **Stock APIs** section

## What is Adanos Sentiment API?
Finance Sentiment API unifies Reddit, X/Twitter, financial news, Polymarket, and crypto community data in one API for sentiment analysis and market research.

**Key features:**
- Trending stocks & crypto with buzz scores, sentiment, and trend direction
- Per-ticker detail with daily trends, bullish/bearish percentages
- Sector and country breakdowns
- Cross-platform comparison (Reddit + X/Twitter)
- Free tier available

API docs: https://api.adanos.org/docs/