### PR TITLE
Add Helium MCP - ML option pricing + bias analysis API for AI assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The curated list of resources for research and learning about stock trading and 
 - [Nasdaq Data Link](https://data.nasdaq.com) - Nasdaq Data Link offers a premier source for financial, economic and alternative datasets.
 - [Massive](https://massive.com/) - Massive offers APIs for realtime and historical stock data, forex, and cryptocurrency data.
 - [Refinitiv Eikon Data](https://www.refinitiv.com/en/products/eikon-trading-software/eikon-app-api-innovation/eikon-data-api) - The Eikon Data API allows applications to access data directly from Eikon or Refinitv Workspace.
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Free remote MCP server giving AI assistants (Claude, Cursor) per-symbol ML option fair-value estimates with probability-ITM, daily-ranked long-vol/short-vol strategy lists, and structured news bias analysis.
 
 ## Knowledge
 - [Investopedia](https://www.investopedia.com) - Investopedia.com is a website that provides educational content, news, analysis, and tools related to investing, finance, and business.


### PR DESCRIPTION
Adding [Helium MCP](https://github.com/connerlambden/helium-mcp) under Stock APIs.

It's a free, open MCP (Model Context Protocol) server that gives AI assistants like Claude and Cursor:
- **`get_option_price`** - per-symbol ML model returning predicted fair value + probability-ITM (e.g., AAPL $200c 5/15: $20.64, prob_itm 0.52)
- **`get_top_trading_strategies`** - daily-ranked long-vol vs short-vol candidates with bull/bear cases comparing Helium IV vs market IV
- **`get_ticker`** - real-time quotes
- **`search_balanced_news`** - synthesized multi-source news with structured bias scores

For traders using AI assistants, this means asking "is this option fairly priced?" and getting a real ML answer instead of generic chatbot output. Free, no signup, one-line setup (`npx mcp-remote https://heliumtrades.com/mcp`).

Thanks for considering!

Made with [Cursor](https://cursor.com)