### PR TITLE
docs: tighten contributing flow + fix README headings and stock exchanges

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,70 +1,31 @@
-> **⚠️ IMPORTANT:** Sources are required for claims such as:
-> - "2+ independent book reviews"
-> - "Academic citations or educational usage"
-> - "Multiple editions indicating sustained relevance"
-> - "Industry recognition (awards, expert recommendations)"
-> - "Covered by reputable financial media" (2+ independent sources)
-> - "Significant community adoption/user base"
-> - "Referenced in technical/educational materials"
+> **⚠️ Sources are required for every factual claim below.** Low-effort
+> submissions and promotional content will be closed without comment.
 >
-> **For Books:** Only books published by a recognized publisher are accepted.
-> Self-published books will NOT be accepted.
+> **Books:** Only books from a recognized publisher — no self-published titles.
 >
-> **For Websites, Tools, APIs:** Resources will NOT be accepted if the website
-> lacks clear information about the legal entity/identity. A simple "© by XYZ"
-> or anonymous contact form is considered an indication that this is NOT a
-> legitimate financial industry company.
->
-> List all sources in the "Sources" section below.
+> **Websites / Tools / APIs:** Must clearly identify the legal entity behind
+> the site (company name, imprint, real contact address). A "© XYZ" footer
+> or an anonymous contact form is not enough.
 
-## Resource Information
+## Resource
 - **Name:**
 - **URL:**
-- **Category:** [Books|Website|Tool|API|Other]
+- **Type:** [Book | Website | Tool | API]
+- **Target README section:** (e.g. Stock Research, News, Books, …)
 
-## Relevance Criteria Checklist
+## Checklist
+- [ ] Directly about stock trading or investing
+- [ ] Not already in the list, not promotional
+- [ ] **Book:** published by a recognized publisher
+- [ ] **Website / Tool / API:** legal entity clearly identifiable
+- [ ] **Website / Tool / API:** at least 3 years old (if younger, explain why
+      it still qualifies in "Why include")
 
-### Mandatory (all resources)
-- [ ] Directly related to stock trading or investing
-- [ ] Not promotional content
-- [ ] Not already in the list
+## Why include
+Short justification plus links that back it up — reviews, media coverage,
+user base, citations, awards. **This section decides whether the PR is
+accepted.**
 
-### Age Requirement
-- [ ] Books: No minimum age requirement
-- [ ] Technical resources (tools, APIs, websites): At least 3 years old OR qualifies for exception
-
-### For Books (select at least 2)
-- [ ] Published by a recognized publisher (no self-published books)
-- [ ] 2+ independent book reviews
-- [ ] Academic citations or educational usage
-- [ ] Multiple editions indicating sustained relevance
-- [ ] Industry recognition (awards, expert recommendations)
-
-### For Technical Resources - Websites, Tools, APIs (select at least 2)
-- [ ] Covered by reputable financial media (2+ independent sources)
-- [ ] Significant community adoption/user base
-- [ ] Referenced in technical/educational materials
-- [ ] Industry recognition (awards, expert recommendations)
-
-### Exception (for technical resources only, optional)
-- [ ] New resource (under 3 years) with exceptional circumstances:
-  - [ ] Recommended by established sources (3+ independent confirmations)
-  - [ ] Immediate widespread media coverage
-  - [ ] Unique breakthrough value, meaning:
-    - Provides innovative approach not available elsewhere
-    - Addresses a documented gap in existing resources
-    - NOT merely: UI improvements, copies of existing tools, or hype without substance
-
-## Justification
-Why should this resource be included?
-
-## Additional Information
-- **For Books:** Author, First Publication Year, Goodreads Link
-- **For Technical:** Documentation URL, Community Size (if applicable)
-
-## Sources
-List links to evidence of relevance:
-
----
-
-**Note:** If the relevance criteria are not met, the pull request will be closed without comment. We appreciate the effort you made to contribute to this list and encourage you to submit resources that meet our guidelines in the future.
+## Additional info (optional)
+- **Book:** Author, First Publication Year, ISBN
+- **Technical:** First public release year, Documentation URL

--- a/contributing.md
+++ b/contributing.md
@@ -19,7 +19,7 @@ Marginal fit — fresh launches, founder-submitted own tools without external va
 
 Before contributing, please ensure you follow these guidelines:
 
-1. **Scope:** We welcome contributions that directly relate to stock trading. This includes resources for news, analysis, trading platforms, educational materials, books, blogs, podcasts, and more.
+1. **Scope:** Contributions must fit one of the existing README sections: Stock Research, Market Analysis, Stock Screener, Charting, News, Commentaries, Portfolio Tracker, Strategy Backtesting, Stock Picks, Stock Collections, Stock APIs, Knowledge, Books, or Most Important Stock Exchanges. If you are unsure where a resource belongs, open an issue first.
 
 2. **Quality:** Resources should have an established reputation in the field. Books should be recognized references; websites, tools, and APIs should have a documented user base and at least some independent coverage. Technical resources are typically expected to be at least 3 years old.
 
@@ -38,15 +38,15 @@ To contribute to this list, follow the steps below:
 
 1. **Fork the Repository:** If you're not sure how to do this, GitHub has a great guide that you can follow: [Fork a Repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo).
 
-2. **Update your Fork:** Make your changes to your forked repository. Ensure your additions meet the guidelines mentioned above. Please make sure to place your contribution in the appropriate category, and if a category doesn't exist, feel free to create it.
+2. **Update your Fork:** Add your entry to the appropriate existing README section, keeping the alphabetical order. Use the format: `- [Name](url) - Short description ending with a period.` Do not create new sections; if no existing section fits, open an issue to discuss it first.
 
-3. **Create a Pull Request:** Once you're happy with your changes, create a new pull request. If you need help with creating a pull request, here is another great guide by GitHub: [Creating a pull request from a fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
+3. **Create a Pull Request:** Once you're happy with your changes, create a new pull request. The PR template walks you through the submission checklist and the hard gates — please fill it out completely. GitHub guide: [Creating a pull request from a fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
 
 4. **Review and Merge:** Your pull request will be reviewed by one of the maintainers. They might suggest changes or improvements. Once your contribution is approved, it will be merged into the main repository.
 
 ## Community
 
-Remember that this is a community effort. Be respectful and considerate of others' inputs and viewpoints. All contributions are valued, and together we can create the best curated list of stock trading resources.
+This is a community effort. Be respectful and considerate of others' viewpoints. Thoughtful contributions that meet the guidelines above help keep the list trusted and useful.
 
 Thank you for your contributions!
 

--- a/contributing.md
+++ b/contributing.md
@@ -4,17 +4,33 @@
 
 We appreciate your interest in contributing to our curated list of stock trading resources! This list is aimed at providing valuable and reliable information to anyone interested in stock trading, from beginners to experts. As stock trading evolves, so should our resources, hence we count on contributors like you to keep this list up-to-date and comprehensive.
 
+## What We're Looking For
+
+The list aims to be a reference of **established, trusted entries** — not a discovery feed for anything new. Good contributions typically share these traits:
+
+- **Track record:** the resource has been around long enough to be evaluated. Books are cited or reviewed; websites, tools, and APIs have a user base and public coverage.
+- **Clear operator:** websites, tools, and APIs are run by an identifiable legal entity working in the financial industry.
+- **Filling a gap:** the resource covers an angle, market, or use case that is not already represented in the list.
+- **Substance over polish:** useful content or functionality matters more than a sleek landing page.
+
+Marginal fit — fresh launches, founder-submitted own tools without external validation, or resources that largely duplicate existing entries — will usually be closed.
+
 ## Guidelines
 
 Before contributing, please ensure you follow these guidelines:
 
 1. **Scope:** We welcome contributions that directly relate to stock trading. This includes resources for news, analysis, trading platforms, educational materials, books, blogs, podcasts, and more.
 
-2. **Quality:** All resources should be of high quality and respected within the community. Please ensure that your contributions are trusted and reliable sources of information. We strive to maintain a high standard for our resources. We expect the resources contributed to be renowned, profound, and relevant. Only resources that have established a notable reputation for quality and accuracy in the field are accepted. Very young works, or those without a significant community peer review, are not accepted. This is to ensure that the information we curate and distribute is accurate, reliable, and of the highest quality.
+2. **Quality:** Resources should have an established reputation in the field. Books should be recognized references; websites, tools, and APIs should have a documented user base and at least some independent coverage. Technical resources are typically expected to be at least 3 years old.
 
 3. **No promotion:** This list should not be used for promotion. Please only contribute resources that you believe are genuinely beneficial to the community.
 
 4. **Duplicate Check:** Before adding a new resource, please make sure that your suggestion is not already on the list. Duplicate entries will be removed.
+
+5. **Hard Gates:** Contributions are automatically rejected if:
+   - A book is self-published (only recognized publishers accepted).
+   - A website / tool / API does not clearly identify the legal entity behind it — a "© XYZ" footer or an anonymous contact form is not enough.
+   - A website / tool / API is less than 3 years old and the submission does not explain why it still qualifies.
 
 ## How to Contribute
 


### PR DESCRIPTION
## Summary
- Streamlined PR template: anti-spam gates (publisher, legal entity, 3-year rule) + evidence-based "Why include" instead of checkbox theater
- Aligned contributing.md with PR template: added "What We're Looking For", hard gates, correct scope/sections, entry format, PR template reference
- README: fixed book category heading levels (H4 → H3), added 9 missing stock exchanges sorted alphabetically, refined exchange descriptions

## Test plan
- [x] Verify PR template renders correctly on a new PR
- [ ] Verify contributing.md links and section references match README