### PR TITLE
docs: add Adanos Sentiment API to Stock APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The curated list of resources for research and learning about stock trading and 
 - [StockTwits Top 10](https://stocktwits.com/rankings/trending) - StockTwits' list of the top 10 trending stocks.
 
 ## Stock APIs
+- [Adanos Sentiment API](https://adanos.org/) - Sentiment API aggregating Reddit, X, financial news, and Polymarket data for US stocks and crypto.
 - [Alpha Vantage](https://www.alphavantage.co/) - Alpha Vantage offers free APIs for realtime and historical stock data, forex, and cryptocurrency data.
 - [Eodhistoricaldata](https://eodhistoricaldata.com) - Eodhistoricaldata offers APIs for realtime and historical stock data, forex, and cryptocurrency data.
 - [Financial Modeling Prep](https://site.financialmodelingprep.com/) - Financial Modeling Prep API provides real time stock price, company financial statements, major index prices, stock historical data, forex real time rate and cryptocurrencies.


### PR DESCRIPTION
## Summary
Adds [Adanos Sentiment API](https://adanos.org/) to the Stock APIs section.

Sentiment API aggregating Reddit, X, financial news, and Polymarket data for US stocks and crypto. Fills a gap in the existing Stock APIs entries, which focus on price/fundamentals rather than sentiment.

## Context
Re-submission of #25 with the landing-page URL (instead of `/docs/`) and a description aligned with the existing section style. The product is younger than the standard 3-year gate, but accepted as an exception under "Filling a gap" from contributing.md — the imprint (Adanos Software GmbH, Berlin, HRB 202476 B) is clean and the stock-ticker coverage is real.

Closes #25.