### PR TITLE
docs: remove Strike.Market from Stock Research (out of scope)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ The curated list of resources for research and learning about stock trading and 
 - [Morningstar](https://www.morningstar.com) - Provides investment research, ratings, and tools for stocks, mutual funds, and ETFs.
 - [Seeking Alpha](https://seekingalpha.com) - Offers market news and analysis, portfolio management tools, and investment ideas from contributors.
 - [Simply Wall St](https://simplywall.st/) - Simply Wall St. has a unique pictorial approach to quickly and effectively cut through the massive amounts of data to narrow to a select few candidates.
-- [Strike.Market](https://strike.market) - Offers a platform for trading options and derivatives on cryptocurrency markets.
 - [Tip Ranks](https://www.tipranks.com) - Provides ratings and analysis of stocks and financial experts based on their historical performance.
 - [Wall Street Zen](https://www.wallstreetzen.com) - Offers tools for financial analysis, screening, and backtesting of investment strategies.
 - [Wallmine](https://wallmine.com) - Provides stock analysis, screening, and news for individual investors.


### PR DESCRIPTION
## Summary
Removes Strike.Market from the Stock Research section. The entry's own description — *"platform for trading options and derivatives on cryptocurrency markets"* — identifies it as a crypto-derivatives exchange, not a stock research tool. Out of scope for this list.