### PR TITLE
Add ToolsNova to Stock Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The curated list of resources for research and learning about stock trading and 
 - [Seeking Alpha](https://seekingalpha.com) - Offers market news and analysis, portfolio management tools, and investment ideas from contributors.
 - [Simply Wall St](https://simplywall.st/) - Simply Wall St. has a unique pictorial approach to quickly and effectively cut through the massive amounts of data to narrow to a select few candidates.
 - [Tip Ranks](https://www.tipranks.com) - Provides ratings and analysis of stocks and financial experts based on their historical performance.
+- [ToolsNova](https://toolsnova.net) - Free browser-based trading calculators including XAU/USD pip calculator, margin calculator, position size calculator, and forex converters. No signup required.
 - [Wall Street Zen](https://www.wallstreetzen.com) - Offers tools for financial analysis, screening, and backtesting of investment strategies.
 - [Zacks](https://www.zacks.com) - Provides research, analysis, and ratings for stocks and funds based on quantitative models and fundamental data.
 


### PR DESCRIPTION
## Resource
- **Name:** ToolsNova
- **URL:** https://toolsnova.net
- **Type:** Tool
- **Target README section:** Stock Research

## Checklist
- [x] Directly about stock trading or investing
- [x] Not already in the list, not promotional
- [x] Website / Tool / API: legal entity clearly identifiable

## Why include
ToolsNova provides 100 free browser-based trading calculators 
including XAU/USD pip calculator, margin calculator, and position 
size calculator. All tools run client-side with no signup required. 
Although launched in 2024, it already serves traders across multiple 
categories with actively maintained tools.

## Additional info
- First public release: 2024
- Documentation URL: https://toolsnova.net