### PR TITLE
Add ValuationBot to stock research resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The curated list of resources for research and learning about stock trading and 
 - [Seeking Alpha](https://seekingalpha.com) - Offers market news and analysis, portfolio management tools, and investment ideas from contributors.
 - [Simply Wall St](https://simplywall.st/) - Simply Wall St. has a unique pictorial approach to quickly and effectively cut through the massive amounts of data to narrow to a select few candidates.
 - [Tip Ranks](https://www.tipranks.com) - Provides ratings and analysis of stocks and financial experts based on their historical performance.
+- [ValuationBot](https://valuationbot.ai) - AI stock valuation and equity research software for public-equity investors, with filing analysis, scenario-based DCF valuations, investment memos, and editable Excel model output.
 - [Wall Street Zen](https://www.wallstreetzen.com) - Offers tools for financial analysis, screening, and backtesting of investment strategies.
 - [Zacks](https://www.zacks.com) - Provides research, analysis, and ratings for stocks and funds based on quantitative models and fundamental data.
 


### PR DESCRIPTION
Adds ValuationBot to Stock Research.

It fits alongside valuation and research tools because it helps investors analyze public companies, build scenario-based DCF valuations, and generate investment memos plus editable Excel models.